### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -142,7 +142,7 @@
           "MemorySize": 256,
           "Publish": true,
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Tags": {
             "DEPARTMENT": "Assets"
           },
@@ -170,7 +170,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -428,7 +428,7 @@
             "MemorySize": 256,
             "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
             "Role": "arn:aws:iam::123456789012:role/lambda-role",
-            "Runtime": "nodejs12.x",
+            "Runtime": "nodejs16.x",
             "State": "Active",
             "Timeout": 15,
             "TracingConfig": {
@@ -495,7 +495,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -1059,7 +1059,7 @@
               "MemorySize": 256,
               "RevisionId": "850ca006-2d98-4ff4-86db-8766e9d32fe9",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 15,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1084,7 +1084,7 @@
               "MemorySize": 256,
               "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 5,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1173,7 +1173,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 5,
           "TracingConfig": {
@@ -1422,7 +1422,7 @@
           "MemorySize": 128,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"
@@ -1457,7 +1457,7 @@
           "MemorySize": 256,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"

--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3567,7 +3567,7 @@
         "nodejs6.10",
         "nodejs8.10",
         "nodejs14.x",
-        "nodejs12.x",
+        "nodejs16.x",
         "java8",
         "java11",
         "python2.7",

--- a/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs16.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -142,7 +142,7 @@
           "MemorySize": 256,
           "Publish": true,
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Tags": {
             "DEPARTMENT": "Assets"
           },
@@ -170,7 +170,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -428,7 +428,7 @@
             "MemorySize": 256,
             "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
             "Role": "arn:aws:iam::123456789012:role/lambda-role",
-            "Runtime": "nodejs12.x",
+            "Runtime": "nodejs16.x",
             "State": "Active",
             "Timeout": 15,
             "TracingConfig": {
@@ -495,7 +495,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -1059,7 +1059,7 @@
               "MemorySize": 256,
               "RevisionId": "850ca006-2d98-4ff4-86db-8766e9d32fe9",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 15,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1084,7 +1084,7 @@
               "MemorySize": 256,
               "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 5,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1173,7 +1173,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 5,
           "TracingConfig": {
@@ -1422,7 +1422,7 @@
           "MemorySize": 128,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"
@@ -1457,7 +1457,7 @@
           "MemorySize": 256,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3559,7 +3559,7 @@
         "nodejs6.10",
         "nodejs8.10",
         "nodejs14.x",
-        "nodejs12.x",
+        "nodejs16.x",
         "java8",
         "java11",
         "python2.7",

--- a/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs16.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -142,7 +142,7 @@
           "MemorySize": 256,
           "Publish": true,
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Tags": {
             "DEPARTMENT": "Assets"
           },
@@ -170,7 +170,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -428,7 +428,7 @@
             "MemorySize": 256,
             "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
             "Role": "arn:aws:iam::123456789012:role/lambda-role",
-            "Runtime": "nodejs12.x",
+            "Runtime": "nodejs16.x",
             "State": "Active",
             "Timeout": 15,
             "TracingConfig": {
@@ -495,7 +495,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -1059,7 +1059,7 @@
               "MemorySize": 256,
               "RevisionId": "850ca006-2d98-4ff4-86db-8766e9d32fe9",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 15,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1084,7 +1084,7 @@
               "MemorySize": 256,
               "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 5,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1173,7 +1173,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 5,
           "TracingConfig": {
@@ -1422,7 +1422,7 @@
           "MemorySize": 128,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"
@@ -1457,7 +1457,7 @@
           "MemorySize": 256,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3559,7 +3559,7 @@
         "nodejs6.10",
         "nodejs8.10",
         "nodejs14.x",
-        "nodejs12.x",
+        "nodejs16.x",
         "java8",
         "java11",
         "python2.7",

--- a/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs16.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -142,7 +142,7 @@
           "MemorySize": 256,
           "Publish": true,
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Tags": {
             "DEPARTMENT": "Assets"
           },
@@ -170,7 +170,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -428,7 +428,7 @@
             "MemorySize": 256,
             "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
             "Role": "arn:aws:iam::123456789012:role/lambda-role",
-            "Runtime": "nodejs12.x",
+            "Runtime": "nodejs16.x",
             "State": "Active",
             "Timeout": 15,
             "TracingConfig": {
@@ -495,7 +495,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 15,
           "TracingConfig": {
@@ -1059,7 +1059,7 @@
               "MemorySize": 256,
               "RevisionId": "850ca006-2d98-4ff4-86db-8766e9d32fe9",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 15,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1084,7 +1084,7 @@
               "MemorySize": 256,
               "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
               "Role": "arn:aws:iam::123456789012:role/lambda-role",
-              "Runtime": "nodejs12.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 5,
               "TracingConfig": {
                 "Mode": "Active"
@@ -1173,7 +1173,7 @@
           "MemorySize": 256,
           "RevisionId": "b75dcd81-xmpl-48a8-a75a-93ba8b5b9727",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "State": "Active",
           "Timeout": 5,
           "TracingConfig": {
@@ -1422,7 +1422,7 @@
           "MemorySize": 128,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"
@@ -1457,7 +1457,7 @@
           "MemorySize": 256,
           "RevisionId": "873282ed-xmpl-4dc8-a069-d0c647e470c6",
           "Role": "arn:aws:iam::123456789012:role/lambda-role",
-          "Runtime": "nodejs12.x",
+          "Runtime": "nodejs16.x",
           "Timeout": 3,
           "TracingConfig": {
             "Mode": "PassThrough"

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3559,7 +3559,7 @@
         "nodejs6.10",
         "nodejs8.10",
         "nodejs14.x",
-        "nodejs12.x",
+        "nodejs16.x",
         "java8",
         "java11",
         "python2.7",

--- a/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs16.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",


### PR DESCRIPTION
CloudFormation templates in aws-comparing-algorithms-performance-mlops-cdk have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.