### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3566,7 +3566,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs14.x",
+        "nodejs16.x",
         "nodejs12.x",
         "java8",
         "java11",

--- a/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs16.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3558,7 +3558,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs14.x",
+        "nodejs16.x",
         "nodejs12.x",
         "java8",
         "java11",

--- a/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs16.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3558,7 +3558,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs14.x",
+        "nodejs16.x",
         "nodejs12.x",
         "java8",
         "java11",

--- a/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs16.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -856,7 +856,7 @@
               "MemorySize": 128,
               "RevisionId": "1718e831-badf-4253-9518-d0644210af7b",
               "Role": "arn:aws:iam::123456789012:role/service-role/MyTestFunction-role-zgur6bf4",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"
@@ -874,7 +874,7 @@
               "MemorySize": 256,
               "RevisionId": "93017fc9-59cb-41dc-901b-4845ce4bf668",
               "Role": "arn:aws:iam::123456789012:role/service-role/helloWorldPython-role-uy3l9qyq",
-              "Runtime": "nodejs14.x",
+              "Runtime": "nodejs16.x",
               "Timeout": 3,
               "TracingConfig": {
                 "Mode": "PassThrough"

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3558,7 +3558,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
-        "nodejs14.x",
+        "nodejs16.x",
         "nodejs12.x",
         "java8",
         "java11",

--- a/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs16.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",


### PR DESCRIPTION
CloudFormation templates in aws-comparing-algorithms-performance-mlops-cdk have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.