### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/functions/bucketFolderCreator/certifi-2020.4.5.2.dist-info/METADATA
+++ b/functions/bucketFolderCreator/certifi-2020.4.5.2.dist-info/METADATA
@@ -45,12 +45,12 @@ built-in function::
     >>> import certifi
 
     >>> certifi.where()
-    '/usr/local/lib/python3.7/site-packages/certifi/cacert.pem'
+    '/usr/local/lib/python3.10/site-packages/certifi/cacert.pem'
 
 Or from the command line::
 
     $ python -m certifi
-    /usr/local/lib/python3.7/site-packages/certifi/cacert.pem
+    /usr/local/lib/python3.10/site-packages/certifi/cacert.pem
 
 Enjoy!
 

--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -553,7 +553,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",
@@ -945,7 +945,7 @@
     "ListLayers": [
       {
         "input": {
-          "CompatibleRuntime": "python3.7"
+          "CompatibleRuntime": "python3.10"
         },
         "output": {
           "Layers": [
@@ -953,7 +953,7 @@
               "LatestMatchingVersion": {
                 "CompatibleRuntimes": [
                   "python3.6",
-                  "python3.7"
+                  "python3.10"
                 ],
                 "CreatedDate": "2018-11-15T00:37:46.592+0000",
                 "Description": "My layer",
@@ -1109,7 +1109,7 @@
         "input": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "S3Bucket": "lambda-layers-us-west-2-123456789012",
@@ -1122,7 +1122,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",

--- a/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/cleanupLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3572,7 +3572,7 @@
         "java11",
         "python2.7",
         "python3.6",
-        "python3.7",
+        "python3.10",
         "python3.8",
         "dotnetcore1.0",
         "dotnetcore2.0",

--- a/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/cleanupLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.10</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -553,7 +553,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",
@@ -945,7 +945,7 @@
     "ListLayers": [
       {
         "input": {
-          "CompatibleRuntime": "python3.7"
+          "CompatibleRuntime": "python3.10"
         },
         "output": {
           "Layers": [
@@ -953,7 +953,7 @@
               "LatestMatchingVersion": {
                 "CompatibleRuntimes": [
                   "python3.6",
-                  "python3.7"
+                  "python3.10"
                 ],
                 "CreatedDate": "2018-11-15T00:37:46.592+0000",
                 "Description": "My layer",
@@ -1109,7 +1109,7 @@
         "input": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "S3Bucket": "lambda-layers-us-west-2-123456789012",
@@ -1122,7 +1122,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",

--- a/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3564,7 +3564,7 @@
         "java11",
         "python2.7",
         "python3.6",
-        "python3.7",
+        "python3.10",
         "python3.8",
         "dotnetcore1.0",
         "dotnetcore2.0",

--- a/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/describeEndpointLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.10</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -553,7 +553,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",
@@ -945,7 +945,7 @@
     "ListLayers": [
       {
         "input": {
-          "CompatibleRuntime": "python3.7"
+          "CompatibleRuntime": "python3.10"
         },
         "output": {
           "Layers": [
@@ -953,7 +953,7 @@
               "LatestMatchingVersion": {
                 "CompatibleRuntimes": [
                   "python3.6",
-                  "python3.7"
+                  "python3.10"
                 ],
                 "CreatedDate": "2018-11-15T00:37:46.592+0000",
                 "Description": "My layer",
@@ -1109,7 +1109,7 @@
         "input": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "S3Bucket": "lambda-layers-us-west-2-123456789012",
@@ -1122,7 +1122,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",

--- a/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3564,7 +3564,7 @@
         "java11",
         "python2.7",
         "python3.6",
-        "python3.7",
+        "python3.10",
         "python3.8",
         "dotnetcore1.0",
         "dotnetcore2.0",

--- a/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/invokeStateLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.10</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/examples-1.json
@@ -553,7 +553,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",
@@ -945,7 +945,7 @@
     "ListLayers": [
       {
         "input": {
-          "CompatibleRuntime": "python3.7"
+          "CompatibleRuntime": "python3.10"
         },
         "output": {
           "Layers": [
@@ -953,7 +953,7 @@
               "LatestMatchingVersion": {
                 "CompatibleRuntimes": [
                   "python3.6",
-                  "python3.7"
+                  "python3.10"
                 ],
                 "CreatedDate": "2018-11-15T00:37:46.592+0000",
                 "Description": "My layer",
@@ -1109,7 +1109,7 @@
         "input": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "S3Bucket": "lambda-layers-us-west-2-123456789012",
@@ -1122,7 +1122,7 @@
         "output": {
           "CompatibleRuntimes": [
             "python3.6",
-            "python3.7"
+            "python3.10"
           ],
           "Content": {
             "CodeSha256": "tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=",

--- a/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
+++ b/functions/predictionLambda/botocore/data/lambda/2015-03-31/service-2.json
@@ -3564,7 +3564,7 @@
         "java11",
         "python2.7",
         "python3.6",
-        "python3.7",
+        "python3.10",
         "python3.8",
         "dotnetcore1.0",
         "dotnetcore2.0",

--- a/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
+++ b/functions/predictionLambda/botocore/data/securityhub/2018-10-26/service-2.json
@@ -1835,7 +1835,7 @@
         },
         "CompatibleRuntimes":{
           "shape":"NonEmptyStringList",
-          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.7</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
+          "documentation":"<p>The layer's compatible runtimes. Maximum number of five items.</p> <p>Valid values: <code>nodejs14.x</code> | <code>nodejs12.x</code> | <code>java8</code> | <code>java11</code> | <code>python2.7</code> | <code>python3.6</code> | <code>python3.10</code> | <code>python3.8</code> | <code>dotnetcore1.0</code> | <code>dotnetcore2.1</code> | <code>go1.x</code> | <code>ruby2.5</code> | <code>provided</code> </p>"
         },
         "CreatedDate":{
           "shape":"NonEmptyString",


### PR DESCRIPTION
CloudFormation templates in aws-comparing-algorithms-performance-mlops-cdk have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.